### PR TITLE
additions to build: copy(), deepcopy(), rotate!() and extra options to bulk()

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -106,22 +106,15 @@ Atoms(s::Symbol, X::Matrix{Float64}) = Atoms(s, vecs(X))
 # shallow copy constructor
 Atoms(at::Atoms) = Atoms(at.X, at.P, at.M, at.Z, at.cell, at.pbc, at.calc)
 
-import Base.copy, Base.deepcopy
+import Base.copy
 
 """
    at2 = copy(at)
 
 Return a copy of Atoms, referring to same arrays for positions, momenta, etc.
+Use `deepcopy()` for a deep copy of the arrays as well.
 """
 copy(at::Atoms) = Atoms(at)
-
-"""
-   at2 = deepcopy(at) 
-   
-*Note:* `deepcopy(at)` reattaches the original calculator - this is different from ASE, since JuLIP calculators
-are assummed to be stateless.
-"""
-deepcopy(at::Atoms) = Atoms(copy(at.X), copy(at.P), copy(at.M), copy(at.Z), copy(at.cell), copy(at.pbc), at.calc) 
 
 """
    rotation_matrix([x=X, y=Y, z=Z])

--- a/src/build.jl
+++ b/src/build.jl
@@ -142,19 +142,19 @@ function rotation_matrix(; x=nothing, y=nothing, z=nothing)
    z !== nothing && (z /= norm(z))
 
    if x === nothing
-      @assert all(isapprox.(y' * z, atol=1e-6))
+      @assert isapprox(y' * z, 0, atol=1e-6)
       x = cross(y, z)
       x /= norm(x)
    end
 
    if y === nothing
-      @assert all(isapprox.(z' * x, atol=1e-6))
+      @assert isapprox(z' * x, 0, atol=1e-6)
       y = cross(z, x)
       y /= norm(y)
    end
 
    if z === nothing
-      @assert all(isapprox.(x' * y, atol=1e-6))
+      @assert isapprox.(x' * y, 0, atol=1e-6)
       z = cross(x, y)
       z /= norm(z)
    end

--- a/src/build.jl
+++ b/src/build.jl
@@ -142,19 +142,19 @@ function rotation_matrix(; x=nothing, y=nothing, z=nothing)
    z !== nothing && (z /= norm(z))
 
    if x === nothing
-      @assert all(y' * z .≈ 0)
+      @assert all(isapprox.(y' * z, atol=1e-6))
       x = cross(y, z)
       x /= norm(x)
    end
 
    if y === nothing
-      @assert all(z' * x .≈ 0)
+      @assert all(isapprox.(z' * x, atol=1e-6))
       y = cross(z, x)
       y /= norm(y)
    end
 
    if z === nothing
-      @assert all(x' * y .≈ 0)
+      @assert all(isapprox.(x' * y, atol=1e-6))
       z = cross(x, y)
       z /= norm(z)
    end
@@ -304,7 +304,7 @@ function cluster(atu::Atoms{T}, R::Real;
    # find point closest to centre
    x̄ = sum( x[dims] for x in at.X ) / length(at.X)
    i0 = findmin( [norm(x[dims] - x̄) for x in at.X] )[2]
-   if x0 == nothing
+   if x0 === nothing
       x0 = at[i0]
    else
       x0 += at[i0]

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -1,3 +1,20 @@
 
 
 using Test, JuLIP
+
+at = bulk(:Si)
+
+at2 = copy(at)
+@test at == at2
+@test at !== at2
+@test at.X === at2.X
+
+at3 = deepcopy(at)
+@test at == at3
+@test at !== at3
+@test at.X !== at3.X
+@test at.X == at3.X
+
+rot_at = rotate!(deepcopy(at), x=[1,1,1], y=[1,-1,0])
+apply_defm!(rot_at, inv(rotation_matrix(x=[1,1,1], y=[1,-1,0])
+@test rot_at ≈ at

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -16,5 +16,5 @@ at3 = deepcopy(at)
 @test at.X == at3.X
 
 rot_at = rotate!(deepcopy(at), x=[1,1,1], y=[1,-1,0])
-apply_defm!(rot_at, inv(rotation_matrix(x=[1,1,1], y=[1,-1,0])
+apply_defm!(rot_at, inv(rotation_matrix(x=[1,1,1], y=[1,-1,0])))
 @test rot_at ≈ at


### PR DESCRIPTION
The only thing that might be worth discussing is the conventions for `copy(::Atoms)` and `deepcopy(::Atoms)`. The former is a shallow copy refererring to all the same arrays, and the latter copies the arrays as well. Is this what you would have expected, and does it follow Julia norms?

The other additions are hopefully useful to make JuLIP a bit more comfortable: can now create bulk cells with an arbitrary crystallographic orientation, and with specified a and c lattice constants. The addition of the `parity` argument to `cluster()` is to allow for e.g. cracks to be centred correctly. Open to suggestions for a better name for that.