### PR TITLE
Update type of CubicBSpline for `StepRangeLen` introduced in Julia 1.7 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-	  - '1.6'
+          - '1.6'
           - '1.7'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.7'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+	  - '1.6'
           - '1.7'
         os:
           - ubuntu-latest

--- a/src/eam.jl
+++ b/src/eam.jl
@@ -75,7 +75,7 @@ Files can e.g. be obtained from
 `ρ` can be a `Vector`  or a `Matrix`, depending on the symmetry of the density function.
 `.fs` files can provide an assymmetric density.
 """
-struct EAM{T<:Real, N,
+struct EAM{T<:Real, N, 
            P1<:SimplePairPotential, P2<:SimplePairPotential, P3<:SimplePairPotential,
            Z<:AbstractZList} <: SitePotential
    ρ::Array{P1, N}
@@ -181,7 +181,7 @@ end
 Constructor for single species EAM.
 """
 function EAM(ρ::PairPotential, F::PairPotential, ϕ::PairPotential)
-   EAM([ρ], [F], hcat(ϕ), ZList([JuLIP.Chemistry.__zAny__]), max(cutoff(ϕ), cutoff(ρ)))
+   EAM(hcat(ρ), [F], hcat(ϕ), ZList([JuLIP.Chemistry.__zAny__]), max(cutoff(ϕ), cutoff(ρ)))
 end
 
 @pot EAM

--- a/src/splines.jl
+++ b/src/splines.jl
@@ -9,7 +9,6 @@ using Interpolations: interpolate, BSpline, Cubic, Line, OnGrid,
 using OffsetArrays: OffsetVector
 using ForwardDiff
 
-const CubicBSpline{T} = ScaledInterpolation{T, 1, BSplineInterpolation{T, 1, OffsetVector{T, Vector{T}}, BSpline{Cubic{Line{OnGrid}}}, Tuple{Base.OneTo{Int64}}}, BSpline{Cubic{Line{OnGrid}}}, Tuple{StepRangeLen{T, Base.TwicePrecision{T}, Base.TwicePrecision{T}, Int64}}}
 
 """
 `type SplinePairPotential`
@@ -26,14 +25,15 @@ SplinePairPotential(fname; kwargs...)        # load data points from file
 Keyword arguments:
 * `fixcutoff = true`: if true, then the fit will be artificially modified at the cut-off to ensure that the transition to zero is smooth
 """
-mutable struct SplinePairPotential{T} <: SimplePairPotential
-   spl::CubicBSpline{T}      # The actual spline object
+mutable struct SplinePairPotential{T, SPL} <: SimplePairPotential
+   spl::SPL      # The actual spline object
    rcut::T                   # cutoff radius (??? could just use spl.t[end] ???)
 end
 
 @pot SplinePairPotential
 
-function SplinePairPotential(xdat, ydat, rcut = xdat[end]; fixcutoff=true) 
+function SplinePairPotential(xdat::AbstractVector, ydat::AbstractVector, 
+                             rcut::Real = xdat[end]; fixcutoff=true)
    # check that the data is equi-spaced. If not, then we need to generalize the 
    # code to allow splines on arbitrary grids (griddedinterpolations?)
    if maximum(abs, diff(diff(xdat))) > 1e-12 
@@ -56,7 +56,7 @@ function SplinePairPotential(xdat, ydat, rcut = xdat[end]; fixcutoff=true)
    spl_pre = interpolate(ydat, BSpline(Cubic(Line(OnGrid()))))
    # ... and rescale it to the correct grid 
    spl = Interpolations.scale(spl_pre, xrg)
-   return SplinePairPotential(spl, rcut)
+   return SplinePairPotential{typeof(rcut), typeof(spl)}(spl, rcut)
 end
 
 

--- a/src/splines.jl
+++ b/src/splines.jl
@@ -9,7 +9,7 @@ using Interpolations: interpolate, BSpline, Cubic, Line, OnGrid,
 using OffsetArrays: OffsetVector
 using ForwardDiff
 
-const CubicBSpline{T} = ScaledInterpolation{T, 1, BSplineInterpolation{T, 1, OffsetVector{T, Vector{T}}, BSpline{Cubic{Line{OnGrid}}}, Tuple{Base.OneTo{Int64}}}, BSpline{Cubic{Line{OnGrid}}}, Tuple{StepRangeLen{T, Base.TwicePrecision{T}, Base.TwicePrecision{T}}}}
+const CubicBSpline{T} = ScaledInterpolation{T, 1, BSplineInterpolation{T, 1, OffsetVector{T, Vector{T}}, BSpline{Cubic{Line{OnGrid}}}, Tuple{Base.OneTo{Int64}}}, BSpline{Cubic{Line{OnGrid}}}, Tuple{StepRangeLen{T, Base.TwicePrecision{T}, Base.TwicePrecision{T}, Int64}}}
 
 """
 `type SplinePairPotential`
@@ -56,7 +56,6 @@ function SplinePairPotential(xdat, ydat, rcut = xdat[end]; fixcutoff=true)
    spl_pre = interpolate(ydat, BSpline(Cubic(Line(OnGrid()))))
    # ... and rescale it to the correct grid 
    spl = Interpolations.scale(spl_pre, xrg)
-
    return SplinePairPotential(spl, rcut)
 end
 


### PR DESCRIPTION
Tested with Interpolations.jl v0.13.5.

Maybe we need to add some version bounds as well?

Spline tests now pass using `eam_from_ase()` when ASE.jl is available, but `eam_from_fs()` is still failing due to a type mismatch.