### PR TITLE
Use views instead of slicing

### DIFF
--- a/src/mlips.jl
+++ b/src/mlips.jl
@@ -216,7 +216,7 @@ function energy(shipB::IPBasis, at::AbstractAtoms{T}) where {T}
       j, R, Z = neigsz!(tmpRZ, nlist, at, i)
       fill!(B, 0)
       evaluate!(B, tmp, shipB, R, Z, at.Z[i])
-      E[:] .+= B[:]
+      E .+= B
    end
    return E
 end
@@ -246,8 +246,8 @@ function forces_inner!(shipB::IPBasis, at::AbstractAtoms{T},
       fill!(B, 0)
       evaluate_d!(dB, tmp, shipB, R, Z, at.Z[i])
       for a = 1:length(R)
-         F[j[a], :] .-= dB[:, a]
-         F[i, :] .+= dB[:, a]
+         F[j[a], :] .-= @view dB[:, a]
+         F[i, :] .+= @view dB[:, a]
       end
    end
    return [ F[:, iB] for iB = 1:length(shipB) ]
@@ -271,7 +271,7 @@ function virial(shipB::IPBasis, at::AbstractAtoms{T}) where {T}
       fill!(dB, zero(JVec{T}))
       evaluate_d!(dB, tmp, shipB, R, Z, at.Z[i])
       for iB = 1:length(shipB)
-         V[iB] += site_virial(dB[iB, :], R)
+         V[iB] += site_virial( view( dB, iB, : ), R)
       end
    end
    return V


### PR DESCRIPTION
This will cut about 10% of evaluation time, might depend on system though.

I tested with single process and 8 processes, the speed increase is the same in both of the cases.

It is not that much, but it is something and not having this is also waste.