### PR TITLE
Check compatibility of Julia versions 1.7 to 1.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.7'
+          - '1.8'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
tests fail for 1.6, before we put version bounds I'm running CI for 1.7, 1.8, 1.9