### PR TITLE
Added OneBody site_energy and site_energy_d methods

### DIFF
--- a/src/onebody.jl
+++ b/src/onebody.jl
@@ -42,6 +42,13 @@ forces(V::OneBody, at::AbstractAtoms{T}) where {T} = zeros(JVec{T}, length(at))
 
 virial(V::OneBody, at::AbstractAtoms{T}) where {T} = zero(JMat{T})
 
+site_energy(V::OneBody, at::AbstractAtoms{T}, i::Int) where {T} =
+   V(chemical_symbols(at)[i])
+
+site_energy_d(V::OneBody, at::AbstractAtoms{T}, i::Int) where {T} =
+   zeros(JVec{T}, length(at))
+
+
 write_dict(V::OneBody) =
          Dict("__id__" => "JuLIP_OneBody",
               "E0" => Dict([String(key) => val for (key, val) in V.E0]...))


### PR DESCRIPTION
Added functions to OneBody.jl to fix breaking behaviour with a view to resolve #173 .

Could it please be confirmed that the implemented functions do the right thing for a OneBody potential?